### PR TITLE
fix: Renovate is a bot

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -10,5 +10,6 @@
         ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }
-  ]
+  ],
+  addLabels: ["bot"],
 }


### PR DESCRIPTION
This label will let the infamous pr title check workflow filter out renovate PRs.